### PR TITLE
fix(example): prevent reconnecting after closing the connection

### DIFF
--- a/example/pages/index.vue
+++ b/example/pages/index.vue
@@ -67,9 +67,9 @@
           Open connection
         </button>
         <button
-          :disabled="!msgSend"
+          :disabled="isSendDisabled"
           class="btn btn-blue"
-          :class="{ 'cursor-not-allowed opacity-50': !msgSend }"
+          :class="{ 'cursor-not-allowed opacity-50': isSendDisabled}"
           @click.prevent="sendMessage"
         >
           Send message
@@ -105,6 +105,9 @@ export default {
         closed: 'Connection closed!'
       }
       return statusMap[this.connectionStatus]
+    },
+    isSendDisabled () {
+      return !this.msgSend || this.connectionStatus === 'closed'
     }
   },
   mounted () {
@@ -120,7 +123,7 @@ export default {
       this.toggleProperties()
     },
     closeConnection () {
-      this.$socketManager.close()
+      this.$socketManager.close(1000)
       this.toggleProperties(false)
       this.msgSend = ''
       this.msgReceived = ''


### PR DESCRIPTION
## Description
The close method invocation without any arguments resulted in a code of `1005` -> No status received. This PR aims at preventing the reconnect behavior on closing the connection with a code other than `1000`.

- Specify the close code as `1000` -> normal close event.
- Disable the `send` button while the connection is closed.

https://user-images.githubusercontent.com/87924230/157421238-2cc4d381-efd8-4524-ba87-ad2d2290427d.mov

