### PR TITLE
docs: add compatibility note

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@
 
 </div>
 
+> This module is only compatible with Nuxt v2 at the moment.
+
 ## Setup
 
 1. Add `@deepsource/nuxt-websocket` dependency to your project.


### PR DESCRIPTION
## Description
The module is only compatible with Nuxt v2 at the moment. This PR aims at adding this information to the docs.
### Type of change
- [x] Docs update.